### PR TITLE
added header for concatenateFields

### DIFF
--- a/texture_mapping.cpp
+++ b/texture_mapping.cpp
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <pcl/common/io.h> // for concatenateFields
 #include <pcl/common/transforms.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/io/obj_io.h>

--- a/texture_mapping.cpp
+++ b/texture_mapping.cpp
@@ -53,6 +53,7 @@
 #include <pcl/surface/texture_mapping.h>
 
 using namespace pcl;
+using namespace std;
 
 std::ifstream& go_to_line(std::ifstream& file, unsigned int num) {
   file.seekg(std::ios::beg);


### PR DESCRIPTION
The python package was not installing due to lack of header for concatenateFields.